### PR TITLE
add comment warning for issue#1

### DIFF
--- a/ai-engine/app/models/issue.py
+++ b/ai-engine/app/models/issue.py
@@ -44,6 +44,9 @@ class IssueMetadata(BaseModel):
     
     # Ingestion metadata
     ingested_at: int = 0  # Unix timestamp
+
+    # Claim detection (analyze comments for "I'll work on this" patterns)
+    has_claimer: bool = False
     
     @computed_field
     @property

--- a/ai-engine/app/models/query.py
+++ b/ai-engine/app/models/query.py
@@ -56,6 +56,7 @@ class SearchResult(BaseModel):
     # New fields
     is_assigned: bool = False
     assignees_count: int = 0
+    has_claimer: bool = False
     repo_description: str | None = None
     repo_topics: list[str] = []
     repo_license: str | None = None

--- a/ai-engine/app/services/search_engine.py
+++ b/ai-engine/app/services/search_engine.py
@@ -300,6 +300,7 @@ class SearchEngine:
             score=match["score"],
             is_assigned=metadata.get("is_assigned", False),
             assignees_count=metadata.get("assignees_count", 0),
+            has_claimer=metadata.get("has_claimer", False),
             repo_description=metadata.get("repo_description"),
             repo_topics=metadata.get("repo_topics", []),
             repo_license=metadata.get("repo_license")

--- a/web-platform/src/components/finder/IssueCard.tsx
+++ b/web-platform/src/components/finder/IssueCard.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { StarIcon, ChatBubbleLeftIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { StarIcon, ChatBubbleLeftIcon, ArrowTopRightOnSquareIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { StartWorkingButton } from '@/components/finder/StartWorkingButton';
 import { SearchResult } from '@/lib/api';
 
@@ -127,11 +128,24 @@ export function IssueCard({ issue, index, userId }: IssueCardProps) {
                     )}
 
                     {/* Footer */}
-                    <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                        <span className="flex items-center gap-1">
-                            <ChatBubbleLeftIcon className="h-4 w-4" />
-                            {issue.comments_count} comments
-                        </span>
+                    <div className="flex items-center gap-4 text-xs text-muted-foreground flex-wrap">
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <span className="flex items-center gap-1 cursor-help">
+                                    {issue.has_claimer && (!issue.assignees_count || issue.assignees_count === 0) && (
+                                        <ExclamationTriangleIcon className="h-4 w-4 text-amber-500" />
+                                    )}
+                                    <ChatBubbleLeftIcon className="h-4 w-4" />
+                                    <span>{issue.comments_count}</span>
+                                </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p>{issue.comments_count} comments</p>
+                                {issue.has_claimer && (!issue.assignees_count || issue.assignees_count === 0) && (
+                                    <p className="text-amber-500">Someone may already be working on this issue</p>
+                                )}
+                            </TooltipContent>
+                        </Tooltip>
                         <span>Created: {formatDate(issue.created_at)}</span>
                         <span>Updated: {formatDate(issue.updated_at)}</span>
                         <span className="ml-auto flex items-center gap-2">

--- a/web-platform/src/components/finder/SearchResults.tsx
+++ b/web-platform/src/components/finder/SearchResults.tsx
@@ -5,6 +5,7 @@ import { SearchResult } from '@/lib/api';
 import { IssueCard } from './IssueCard';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 interface SearchResultsProps {
     results: SearchResult[];
@@ -41,19 +42,21 @@ export function SearchResults({ results, isLoading, userId }: SearchResultsProps
     }
 
     return (
-        <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="space-y-4"
-        >
-            <p className="text-sm text-muted-foreground mb-4">
-                Found {results.length} contribution opportunities
-            </p>
-            <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-6">
-                {results.map((issue, index) => (
-                    <IssueCard key={issue.issue_id} issue={issue} index={index} userId={userId} />
-                ))}
-            </div>
-        </motion.div>
+        <TooltipProvider>
+            <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="space-y-4"
+            >
+                <p className="text-sm text-muted-foreground mb-4">
+                    Found {results.length} contribution opportunities
+                </p>
+                <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-6">
+                    {results.map((issue, index) => (
+                        <IssueCard key={issue.issue_id} issue={issue} index={index} userId={userId} />
+                    ))}
+                </div>
+            </motion.div>
+        </TooltipProvider>
     );
 }

--- a/web-platform/src/lib/api.ts
+++ b/web-platform/src/lib/api.ts
@@ -21,6 +21,7 @@ export interface SearchResult {
   score: number;
   is_assigned?: boolean;
   assignees_count?: number;
+  has_claimer?: boolean;
   repo_description?: string | null;
   repo_topics?: string[];
   repo_license?: string | null;


### PR DESCRIPTION
# **Feature Description**

Detects whether someone has claimed a GitHub Issue in the comments (e.g., "I'll work on this", "Can I take this?") and displays a warning in the UI if applicable.

---

## **Backend Changes**

1. **`ai-engine/app/models/issue.py`**

   * Added a new field `has_claimer: bool = False` to the `IssueMetadata` model
   * Used to store the result of comment analysis

2. **`ai-engine/app/models/query.py`**

   * Added a new field `has_claimer: bool = False` to the `SearchResult` model
   * Returned in API responses to the frontend

3. **`ai-engine/app/services/search_engine.py`**

   * Updated `_create_result()` method to include `has_claimer=metadata.get("has_claimer", False)`
   * Passes the `has_claimer` field from data fetched from Pinecone

4. **`ai-engine/app/services/graphql_fetcher.py`**

   * GraphQL query updated: fetch 30 comments for analysis
   * Added retrieval of comment `body` and `author`
   * Added `_analyze_comments_for_claimer()` method with regex logic

     * Detection patterns include:

       * "I'll work on this" / "I will work on it"
       * "Can I take this?" / "Can I work on it?"
       * "Please assign me" / "Assign me"
       * "I'm working on this" / "I'm taking this"
       * "Started working on this"
       * "Taking this" / "Taking care of it"
       * "On it!"
       * "Begin working on this"
     * Automatically skips bot comments (e.g., `github-actions[bot]`)
   * `_node_to_metadata()` updated to call the comment analysis function and set the `has_claimer` field

---

## **Frontend Changes**

6. **`web-platform/src/lib/api.ts`**

   * Added optional field `has_claimer?: boolean` to the `SearchResult` interface

7. **`web-platform/src/components/finder/IssueCard.tsx`**

   * Imported `ExclamationTriangleIcon` and `Tooltip` components
   * UI logic:

     * Display comment count and comment icon normally
     * Show a warning icon if `has_claimer = true` and the issue is unassigned
   * Tooltip text: `"Someone may already be working on this issue"`

8. **`web-platform/src/components/finder/SearchResults.tsx`**

   * Imported and added `TooltipProvider` to wrap the results area
   * Provides context for tooltips

---

## **Limitations**

1. **Analyzes the first 30 comments**
2. **Regex-based detection**
3. **English-only support**
