### PR TITLE
fix: fetch latest issue comments using last instead of first

### DIFF
--- a/ai-engine/app/services/graphql_fetcher.py
+++ b/ai-engine/app/services/graphql_fetcher.py
@@ -48,7 +48,7 @@ query SearchIssues($query: String!, $cursor: String) {
             login
           }
         }
-        comments(first: 30) {
+        comments(last: 30) {
           totalCount
           nodes {
             body


### PR DESCRIPTION
# Backend Change
`ai-engine/app/services/graphql_fetcher.py`
- use `last: 30` instead of `first: 30`